### PR TITLE
Add initial database scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # verify-event-system-database-scripts
-SQL scripts and schemas for the Event System database
+
+SQL scripts and schemas for the Event System database.
+
+## Migrations
+
+The migrations directory holds the SQL scripts which were used to create the current database. They are used by the
+[verify-event-recorder-service](https://github.com/alphagov/verify-event-recorder-service) and the
+[verify-billing-reporter](https://github.com/alphagov/verify-billing-reporter) tests.
+
+## Permissions
+
+The permissions directory contains the SQL scripts that were used to create and then later revoke the reader and writer
+users. These were replaced by IAM permissions. Only here as a historical reference.

--- a/migrations/V1__create_audit_events_table.sql
+++ b/migrations/V1__create_audit_events_table.sql
@@ -1,0 +1,15 @@
+CREATE SCHEMA audit AUTHORIZATION postgres;
+
+CREATE TABLE audit.audit_events
+(
+    event_id             text COLLATE pg_catalog."default" NOT NULL,
+    time_stamp           timestamp                         NOT NULL,
+    originating_service  text COLLATE pg_catalog."default" NOT NULL,
+    session_id           text COLLATE pg_catalog."default",
+    event_type           text COLLATE pg_catalog."default" NOT NULL,
+    details              jsonb,
+    PRIMARY KEY (event_id, time_stamp)
+)
+TABLESPACE pg_default;
+ALTER TABLE audit.audit_events OWNER to postgres;
+CREATE INDEX ON audit.audit_events (time_stamp);

--- a/migrations/V2__create_billing_and_fraud_events_table.sql
+++ b/migrations/V2__create_billing_and_fraud_events_table.sql
@@ -1,0 +1,33 @@
+CREATE SCHEMA billing AUTHORIZATION postgres;
+
+CREATE TABLE billing.billing_events
+(
+    time_stamp                   timestamp                         NOT NULL,
+    session_id                   text COLLATE pg_catalog."default" NOT NULL,
+    hashed_persistent_id         text COLLATE pg_catalog."default" NOT NULL,
+    request_id                   text COLLATE pg_catalog."default" NOT NULL,
+    idp_entity_id                text COLLATE pg_catalog."default" NOT NULL,
+    minimum_level_of_assurance   text COLLATE pg_catalog."default" NOT NULL,
+    required_level_of_assurance  text COLLATE pg_catalog."default" NOT NULL,
+    provided_level_of_assurance  text COLLATE pg_catalog."default" NOT NULL
+)
+TABLESPACE pg_default;
+ALTER TABLE billing.billing_events OWNER to postgres;
+CREATE INDEX ON billing.billing_events (time_stamp);
+CREATE INDEX ON billing.billing_events (hashed_persistent_id);
+CREATE INDEX ON billing.billing_events (provided_level_of_assurance);
+
+CREATE TABLE billing.fraud_events
+(
+    time_stamp            timestamp                         NOT NULL,
+    session_id            text COLLATE pg_catalog."default" NOT NULL,
+    hashed_persistent_id  text COLLATE pg_catalog."default" NOT NULL,
+    request_id            text COLLATE pg_catalog."default",
+    entity_id             text COLLATE pg_catalog."default" NOT NULL,
+    fraud_event_id        text COLLATE pg_catalog."default" NOT NULL,
+    fraud_indicator       text COLLATE pg_catalog."default" NOT NULL
+)
+TABLESPACE pg_default;
+ALTER TABLE billing.fraud_events OWNER to postgres;
+CREATE INDEX ON billing.fraud_events (time_stamp);
+CREATE INDEX ON billing.fraud_events (hashed_persistent_id);

--- a/migrations/V3__create_indexes_for_audit_billing_and_fraud_events_tables.sql
+++ b/migrations/V3__create_indexes_for_audit_billing_and_fraud_events_tables.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ON audit.audit_events (event_id);
+CREATE INDEX ON billing.billing_events (session_id);
+CREATE INDEX ON billing.fraud_events (session_id);

--- a/permissions/create_iam_reader_permissions.sql
+++ b/permissions/create_iam_reader_permissions.sql
@@ -1,0 +1,8 @@
+GRANT USAGE ON SCHEMA audit TO iam_reader;
+GRANT USAGE ON SCHEMA billing TO iam_reader;
+GRANT SELECT ON audit.audit_events TO iam_reader;
+GRANT SELECT ON billing.billing_events TO iam_reader;
+GRANT SELECT ON billing.fraud_events TO iam_reader;
+GRANT TEMPORARY on DATABASE events TO iam_reader;
+-- Production and staging only
+GRANT SELECT ON billing.billing_idps TO iam_reader;

--- a/permissions/create_iam_writer_permissions.sql
+++ b/permissions/create_iam_writer_permissions.sql
@@ -1,0 +1,7 @@
+GRANT USAGE ON SCHEMA audit TO iam_writer;
+GRANT USAGE ON SCHEMA billing TO iam_writer;
+GRANT SELECT, INSERT, DELETE ON audit.audit_events TO iam_writer;
+GRANT SELECT, INSERT, DELETE ON billing.billing_events TO iam_writer;
+GRANT SELECT, INSERT, DELETE ON billing.fraud_events TO iam_writer;
+-- Production and staging only
+GRANT SELECT, INSERT, DELETE ON billing.billing_idps TO iam_writer;

--- a/permissions/revoke_reader_user_permissions.sql
+++ b/permissions/revoke_reader_user_permissions.sql
@@ -1,0 +1,9 @@
+REVOKE ALL PRIVILEGES ON DATABASE events FROM reader;
+REVOKE CONNECT ON DATABASE events FROM reader;
+REVOKE ALL ON billing.fraud_events FROM reader;
+REVOKE ALL ON billing.billing_events FROM reader;
+REVOKE ALL ON audit.audit_events FROM reader;
+REVOKE ALL ON SCHEMA billing FROM reader;
+REVOKE ALL ON SCHEMA audit FROM reader;
+-- Production and staging only
+REVOKE ALL ON billing.billing_idps FROM reader;

--- a/permissions/revoke_writer_permissions.sql
+++ b/permissions/revoke_writer_permissions.sql
@@ -1,0 +1,9 @@
+REVOKE ALL PRIVILEGES ON DATABASE events FROM writer;
+REVOKE CONNECT ON DATABASE events FROM writer;
+REVOKE USAGE ON SCHEMA audit FROM writer;
+REVOKE USAGE ON SCHEMA billing FROM writer;
+REVOKE SELECT, INSERT, DELETE ON audit.audit_events FROM writer;
+REVOKE SELECT, INSERT, DELETE ON billing.billing_events FROM writer;
+REVOKE SELECT, INSERT, DELETE ON billing.fraud_events FROM writer;
+-- Production and staging only
+REVOKE SELECT, INSERT, DELETE ON billing.billing_idps FROM writer;


### PR DESCRIPTION
This adds the SQL scripts from the [verify-event-recorder-service](https://github.com/alphagov/verify-event-recorder-service).

Going forward all related scripts, schemas and migrations will be held in this repo.

https://trello.com/c/OTm06vLt/67-move-database-sql-scripts-to-new-repo