### PR TITLE
j6bt2ppz: Modify pipeline to include steps to build db migrations image for default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.3'
 
 services:
   event-store:
@@ -9,7 +9,6 @@ services:
       - POSTGRES_DB=events
 
   tests:
-    build:
-      context: .
+    image: platform-deployer-verify-data-db-migrations:test
     depends_on:
       - event-store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       - POSTGRES_DB=events
 
   tests:
-    image: platform-deployer-verify-data-db-migrations:test
+    image: platform-deployer-verify-data-db-migrations:latest-tests
     depends_on:
       - event-store

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,10 +11,10 @@ function stop_containers() {
   echo "Stopping and Cleaning Up Containers..."
   docker-compose down -v --remove-orphans
 }
-
-echo "Starting Container Build..."
-docker-compose build
-
+if [[ "$1" != "--no-build" ]]; then
+    echo "Starting Container Build..."
+    docker build -t platform-deployer-verify-data-db-migrations:test .
+fi
 start_postgres
 
 docker-compose run tests migrate
@@ -23,12 +23,12 @@ MIGRATION_RESULT=$?
 stop_containers
 
 if [[ $MIGRATION_RESULT == 0 ]]; then
-    echo "\033[32m*******************************"
-    echo "\033[32m** Migrations Test Succeeded **"
-    echo "\033[32m*******************************"
+    printf "\033[32m*******************************\n"
+    printf "\033[32m** Migrations Test Succeeded **\n"
+    printf "\033[32m*******************************\n\033[0m"
 else
-    echo "\033[31m****************************"
-    echo "\033[31m** Migrations Test Failed **"
-    echo "\033[31m****************************"
+    printf "\033[31m****************************\n"
+    printf "\033[31m** Migrations Test Failed **\n"
+    printf "\033[31m****************************\n\033[0m"
     exit $MIGRATION_RESULT
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 function start_postgres(){
     echo "Starting Postgres Service Container..."
@@ -23,12 +23,12 @@ MIGRATION_RESULT=$?
 stop_containers
 
 if [[ $MIGRATION_RESULT == 0 ]]; then
-    echo -e "\033[32m*******************************"
-    echo -e "\033[32m** Migrations Test Succeeded **"
-    echo -e "\033[32m*******************************"
+    echo "\033[32m*******************************"
+    echo "\033[32m** Migrations Test Succeeded **"
+    echo "\033[32m*******************************"
 else
-    echo -e "\033[31m****************************"
-    echo -e "\033[31m** Migrations Test Failed **"
-    echo -e "\033[31m****************************"
+    echo "\033[31m****************************"
+    echo "\033[31m** Migrations Test Failed **"
+    echo "\033[31m****************************"
     exit $MIGRATION_RESULT
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,7 +13,7 @@ function stop_containers() {
 }
 if [[ "$1" != "--no-build" ]]; then
     echo "Starting Container Build..."
-    docker build -t platform-deployer-verify-data-db-migrations:test .
+    docker build -t platform-deployer-verify-data-db-migrations:latest-tests .
 fi
 start_postgres
 


### PR DESCRIPTION
Modify `run-test.sh` to run in `sh` instead of `bash` so it is compatible with the dc-ind Docker image.
Modify docker-compose.yml version to 3.3 so compatible iwth dc-ind Docker image.

Co-authored-by: Alan Carter <alan.carter@digital.cabinet-office.gov.uk>