### PR TITLE
Nt3YuErJ: Create Flyway User in Terraform

### DIFF
--- a/migrations/V1__create_audit_events_table.sql
+++ b/migrations/V1__create_audit_events_table.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA audit AUTHORIZATION postgres;
+CREATE SCHEMA audit AUTHORIZATION event_system_owner;
 
 CREATE TABLE audit.audit_events
 (
@@ -11,5 +11,5 @@ CREATE TABLE audit.audit_events
     PRIMARY KEY (event_id, time_stamp)
 )
 TABLESPACE pg_default;
-ALTER TABLE audit.audit_events OWNER to postgres;
+ALTER TABLE audit.audit_events OWNER to event_system_owner;
 CREATE INDEX ON audit.audit_events (time_stamp);

--- a/migrations/V2__create_billing_and_fraud_events_table.sql
+++ b/migrations/V2__create_billing_and_fraud_events_table.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA billing AUTHORIZATION postgres;
+CREATE SCHEMA billing AUTHORIZATION event_system_owner;
 
 CREATE TABLE billing.billing_events
 (
@@ -12,7 +12,7 @@ CREATE TABLE billing.billing_events
     provided_level_of_assurance  text COLLATE pg_catalog."default" NOT NULL
 )
 TABLESPACE pg_default;
-ALTER TABLE billing.billing_events OWNER to postgres;
+ALTER TABLE billing.billing_events OWNER to event_system_owner;
 CREATE INDEX ON billing.billing_events (time_stamp);
 CREATE INDEX ON billing.billing_events (hashed_persistent_id);
 CREATE INDEX ON billing.billing_events (provided_level_of_assurance);
@@ -28,6 +28,6 @@ CREATE TABLE billing.fraud_events
     fraud_indicator       text COLLATE pg_catalog."default" NOT NULL
 )
 TABLESPACE pg_default;
-ALTER TABLE billing.fraud_events OWNER to postgres;
+ALTER TABLE billing.fraud_events OWNER to event_system_owner;
 CREATE INDEX ON billing.fraud_events (time_stamp);
 CREATE INDEX ON billing.fraud_events (hashed_persistent_id);

--- a/permissions/change_object_ownership.sql
+++ b/permissions/change_object_ownership.sql
@@ -1,0 +1,5 @@
+ALTER SCHEMA audit OWNER TO event_system_owner;
+ALTER TABLE audit.audit_events OWNER to event_system_owner;
+ALTER SCHEMA billing OWNER TO event_system_owner;
+ALTER TABLE billing.billing_events OWNER to event_system_owner;
+ALTER TABLE billing.fraud_events OWNER to event_system_owner;

--- a/permissions/create_event_store_owner_permissions.sql
+++ b/permissions/create_event_store_owner_permissions.sql
@@ -1,0 +1,1 @@
+GRANT CREATE ON DATABASE events TO event_system_owner;


### PR DESCRIPTION
Add permissions for new role event_system_owner
Change owner of existing objects to event_system_owner
Update existing migration scripts to reflect new owner so that new
environments can be spun up with requirement for additional `postgres` role..