### PR TITLE
iqUc0u8s: Update database migration tests to use same version of postgres as in AWS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   event-store:
-    image: postgres:latest
+    image: postgres:10.6
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
## What

Currently, the database migrations tests run against the `latest` Postgres Docker image, this currently runs Postgres v11.3. However, the version of a Postgres being run in the AWS environments, and hence the version the migrations will run against, is 10.6.

We need to update the tests so they run against the same version of Postgres.

## Why

To avoid any issues that may arise in differences of the SQL commands or Postgres functionality between versions.

## How

Update `docker-compose.yml` to use `10.6` tag instead of `latest` for Postgres image.