### PR TITLE
Ov5QeYtB: Make a billing status table in the database

### DIFF
--- a/migrations/V4__create_billing_status_table.sql
+++ b/migrations/V4__create_billing_status_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE billing.billing_status
+(
+    event_id        TEXT COLLATE pg_catalog."default" NOT NULL,
+    billing_status  TEXT COLLATE pg_catalog."default" NOT NULL,
+    PRIMARY KEY (event_id)
+)
+TABLESPACE pg_default;
+ALTER TABLE billing.billing_status OWNER TO event_system_owner;


### PR DESCRIPTION
## What

A new table in the DB to hold:

+ billing status as a text field
+ event ID 

Determination has been made to use the event_id as the primary key, which currently doesn't exist in `billing_events`, further cards will added to address this problem.

## How
Create schema V4 script to create new table and set appropriate ownership.