### PR TITLE
Bgg1HWGD: Populate new event_id column in billing_events table - Part 1

### DIFF
--- a/migrations/V6__copy_event_id_to_billing_events_table.sql
+++ b/migrations/V6__copy_event_id_to_billing_events_table.sql
@@ -1,0 +1,8 @@
+UPDATE billing.billing_events be
+   SET be.event_id = ae.event_id
+  FROM audit.audit_events ae
+ WHERE be.event_id IS NULL
+   AND ae.session_id = be.session_id
+   AND ae.time_stamp = be.time_stamp
+;
+


### PR DESCRIPTION
## What

The `billing_events` table current has no primary key defined. It has been determined that we should ideally use the event_id for this. Unfortunately, event_id is not currently stored in this table.

This card will populate the new event_id column by matching rows with those from the `audit_events` table and copying the `event_id` across.

There are 26 billing events identified that do not have a corresponding record in `audit_events`. For these 26 rows a random event_id should be generated.

## Why

Storing the `event_id` will enable efficient joins to both the `audit_events` table and the new `billing_status` table.

## How
Add new version schema migration to populate data from `audit_events` table.

## Note

A second PR will be raised to populate any non-matching rows once they have been identified and analysed.