### PR TITLE
BAU: Fix Status Check

### DIFF
--- a/tools/submit_job.py
+++ b/tools/submit_job.py
@@ -7,6 +7,8 @@ from time import sleep
 
 BATCH_SUCCESSFUL_STATUS = 'SUCCEEDED'
 BATCH_FAILURE_STATUS = 'FAILED'
+BATCH_RUNNING_STATUS = 'RUNNING'
+
 BATCH_PROCESSED_STATUSES = [BATCH_FAILURE_STATUS, BATCH_SUCCESSFUL_STATUS]
 
 batch_client = boto3.client('batch', region_name=os.getenv('AWS_REGION', 'eu-west-2'))
@@ -21,15 +23,36 @@ def print_status(current_status, count):
     sys.stdout.flush()
 
 
-def submit_job():
-    env = os.environ['ENVIRONMENT']
+def ok_to_continue(env):
+    res = batch_client.list_jobs(
+        jobStatus=BATCH_RUNNING_STATUS,
+        jobQueue='{}-batch-job-queue'.format(env)
+    )
+
+    job_id = None
+    for job in res['jobSummaryList']:
+        if job['jobName'] == 'run-database-migrations':
+            job_id = job['jobId']
+
+    if job_id:
+        sys.stdout.write('Waiting for previous job with ID %s to complete\n' % job_id)
+        return wait_for_job(job_id) in BATCH_PROCESSED_STATUSES
+    else:
+        return True
+
+
+def submit_job(env):
     res = batch_client.submit_job(
         jobName='run-database-migrations',
-        # These parameters would need to be dynamic based on a passed environment
         jobDefinition='{}-batch-database-migration-job-definition'.format(env),
         jobQueue='{}-batch-job-queue'.format(env)
     )
     job_id = res['jobId']
+
+    return wait_for_job(job_id)
+
+
+def wait_for_job(job_id):
     count = 0
     current_status = ''
 
@@ -38,8 +61,6 @@ def submit_job():
         count += 1
         print_status(current_status, count)
         sleep(10)
-
-    sys.stdout.write('\n\nJob Complete!\n')
 
     return current_status
 
@@ -50,7 +71,17 @@ def get_job_status(job_id):
 
 
 if __name__ == '__main__':
-    status = submit_job()
+    environment = os.environ['ENVIRONMENT']
 
-    if status != BATCH_SUCCESSFUL_STATUS:
+    if not ok_to_continue(environment):
+        sys.stdout.write('\n\nJob cannot continue due to previous job still running!\n')
         sys.exit(1)
+    else:
+        status = submit_job(environment)
+
+        if status != BATCH_SUCCESSFUL_STATUS:
+            sys.stdout.write('\n\nJob did not complete with successful status!\n')
+
+            sys.exit(1)
+
+        sys.stdout.write('\n\nJob Complete!\n')

--- a/tools/submit_job.py
+++ b/tools/submit_job.py
@@ -52,5 +52,5 @@ def get_job_status(job_id):
 if __name__ == '__main__':
     status = submit_job()
 
-    if status == BATCH_FAILURE_STATUS:
+    if status != BATCH_SUCCESSFUL_STATUS:
         sys.exit(1)


### PR DESCRIPTION
The `submit_job.py` script only checked for failure of the batch job
when exiting. This doesn't work for instances where the wait loop times
out. Changing final check to exit non-zero if final status is not
success.

Also, add a check to see if a previous job is still running, and wait for it to terminate, before submitting new job