### PR TITLE
Bgg1HWGD: Populate event_id column in billing_events table (2018)

### DIFF
--- a/migrations/V9__copy_event_id_to_billing_events_table_2018.sql
+++ b/migrations/V9__copy_event_id_to_billing_events_table_2018.sql
@@ -1,0 +1,8 @@
+UPDATE billing.billing_events be
+   SET event_id = ae.event_id
+  FROM audit.audit_events ae
+ WHERE be.time_stamp >= '2018-01-01' AND be.time_stamp < '2019-01-01'
+   AND be.event_id IS NULL
+   AND ae.session_id = be.session_id
+   AND ae.time_stamp = be.time_stamp
+;


### PR DESCRIPTION
## What

The `billing_events` table current has no primary key defined. It has been determined that we should ideally use the event_id for this. Unfortunately, event_id is not currently stored in this table.

This card will populate the new event_id column by matching rows with those from the `audit_events` table and copying the `event_id` across.

There are 26 billing events identified that do not have a corresponding record in `audit_events`. For these 26 rows a random event_id should be generated.

## Why

Storing the `event_id` will enable efficient joins to both the `audit_events` table and the new `billing_status` table.

## How
Update for data in year 2018 by looking up `event_id` in `audit_events` table.

### Note: 

Migration V6 has already been run in `default` and `staging` environments. Choice has been made to split this down into smaller chunks for safe running into production. This will require manual update of Flyway history table to remove entry for V6 in `default` and `staging`.