### PR TITLE
Bgg1HWGD: Populate event_id column in billing_events table (Part 2)

### DIFF
--- a/migrations/V11__generate_event_id_for_NULL_values.sql
+++ b/migrations/V11__generate_event_id_for_NULL_values.sql
@@ -1,0 +1,6 @@
+-- For any rows that don't have a matching audit event, generate a random event_id
+-- The below UUID formula is used instead of having to install the uuid-ossp extension module
+UPDATE billing.billing_events
+   SET event_id = uuid_in(overlay(overlay(md5(random()::text || ':' || clock_timestamp()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring)
+ WHERE event_id IS NULL
+;


### PR DESCRIPTION
## What

The `billing_events` table current has no primary key defined. It has been determined that we should ideally use the event_id for this. Unfortunately, event_id is not currently stored in this table.

This card will populate the new event_id column by matching rows with those from the `audit_events` table and copying the `event_id` across.

There are 26 billing events identified that do not have a corresponding record in `audit_events`. For these 26 rows a random event_id should be generated.

## Why

Storing the `event_id` will enable efficient joins to both the `audit_events` table and the new `billing_status` table.

## How

Add script to populate any unmatched rows that still have a `NULL` value. Simply generate new UUID. There are 26 instances of this in the production database.