### PR TITLE
yMwmQmiE: Make event_id column the primary key for billing_events table

### DIFF
--- a/migrations/V12__create_unique_event_id_index_on_billing_events.sql
+++ b/migrations/V12__create_unique_event_id_index_on_billing_events.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CONCURRENTLY billing_events_pkey ON billing.billing_events (event_id);

--- a/migrations/V13__create_primary_key_on_billing_events.sql
+++ b/migrations/V13__create_primary_key_on_billing_events.sql
@@ -1,0 +1,2 @@
+ALTER TABLE billing.billing_events ALTER COLUMN event_id SET NOT NULL;
+ALTER TABLE billing.billing_events ADD PRIMARY KEY USING INDEX billing_events_pkey;


### PR DESCRIPTION
## What

The `billing_events` table current has no primary key defined. It has been determined that we should ideally use the event_id for this. Unfortunately, event_id is not currently stored in this table.

This card will make the column `NOT NULL` and define it as the primary key for the `billing_events` table.

## Why

Storing the `event_id` will enable efficient joins to both the `audit_events` table and the new `billing_status` table.

## How

Add migration script to build a unique index (concurrently) for the `event_id` column.
Add migration script to make `event_id` unique index the primary key for the `billing_events` table and alter `event_id` column so that it cannot have `NULL` values.