### PR TITLE
THjpCRyp: Add foreign key relation to billing_status table

### DIFF
--- a/migrations/V14__create_foreign_key_constraint_on_billing_status_table.sql
+++ b/migrations/V14__create_foreign_key_constraint_on_billing_status_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE billing.billing_status
+  ADD CONSTRAINT event_id_fkey FOREIGN KEY (event_id) REFERENCES billing.billing_events(event_id)
+   ON DELETE RESTRICT
+   ON UPDATE CASCADE
+;


### PR DESCRIPTION
## What

A new table was created with the following:

+ billing status as a text field
+ event_id

Also, a primary key on the `billing_events` table has been added to include the `event_id` field.

We should now define a `FOREIGN KEY`, `REFERENCE`-ing the billing events table.

See:
https://github.com/alphagov/verify-event-system-database-scripts/pull/21
https://github.com/alphagov/verify-event-system-database-scripts/pull/20
https://github.com/alphagov/verify-event-system-database-scripts/pull/11

## How

Add migration script to add foreign key constraint to the `event_id`
column in the `billing_status` table referencing the `event_id` column
from the `billing_events` table.