### PR TITLE
2VUuo89R: Database permissions for billing status calculator

### DIFF
--- a/permissions/create_billing_status_calculator_permissions.sql
+++ b/permissions/create_billing_status_calculator_permissions.sql
@@ -1,0 +1,4 @@
+GRANT CONNECT ON DATABASE events TO billing_status_calculator;
+GRANT USAGE ON SCHEMA billing TO billing_status_calculator;
+GRANT SELECT ON billing.billing_events TO billing_status_calculator;
+GRANT SELECT, INSERT, UPDATE ON billing.billing_status TO billing_status_calculator;


### PR DESCRIPTION
## What

We now have a shiny new table into which we can persist the calculated billing status for billing events.

We now need to write the thing that will populate the table.

This card will give permissions to the thing so it can read the data it requires and write back to the `billing_status` table.

## Why

Persisting the billing status will enable more efficient billing reports.

Permissions are required to allow the thing to its job.

## How

Add new script to assign permissions for billng status calculator.

N.B. this script will need to be run manually, in each environment, after the user has been terraformed.