### PR TITLE
EDAtonBP: Update billing report to use persisted billing status - Add Index

### DIFF
--- a/migrations/V20190712122100__create_indexes_on_billing_events_for_reports.sql
+++ b/migrations/V20190712122100__create_indexes_on_billing_events_for_reports.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY ON billing.billing_events USING btree (hashed_persistent_id, time_stamp);


### PR DESCRIPTION
# What

We now have the billing status persisted in the database, and it has been verified as correct.

We now need to change the billing report code to use the persisted value instead of calculating the billing status.

It is probably a good idea to have a test that billing status is actually there.

# Why

To improve efficiency of billing report.

# How

Add new index on `billing_status` table to be used in new  `LATERAL` join in billing report.

This is a "starter for 10", we may need to add additional indexes.