### PR TITLE
BQOh2juk: Update Verifications Report to use persisted billing status - Add Index

### DIFF
--- a/migrations/V20190715165000__create_additional_index_on_audit_events_for_reports.sql
+++ b/migrations/V20190715165000__create_additional_index_on_audit_events_for_reports.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY ON audit.audit_events USING btree ((details->> 'session_event_type'), time_stamp)
+ WHERE event_type = 'session_event';

--- a/migrations/V20190715165000__create_additional_index_on_audit_events_for_reports.sql
+++ b/migrations/V20190715165000__create_additional_index_on_audit_events_for_reports.sql
@@ -1,2 +1,15 @@
-CREATE INDEX CONCURRENTLY ON audit.audit_events USING btree ((details->> 'session_event_type'), time_stamp)
- WHERE event_type = 'session_event';
+--
+-- Works well with queries, such as those used in the verifications report, that have WHERE
+-- clauses constructed as below:
+--
+-- WHERE ae.event_type = 'session_event'
+--   AND ae.time_stamp BETWEEN '2019-06-01 00:00:00.000' AND '2019-06-30 23:59:59.999'
+--   AND ae.details->> 'session_event_type' = 'idp_authn_succeeded'
+-- ORDER BY ae.time_stamp
+--
+
+CREATE INDEX CONCURRENTLY idx_verifications_report
+    ON audit.audit_events
+ USING btree (time_stamp, (details->> 'session_event_type'))
+ WHERE event_type = 'session_event'
+;


### PR DESCRIPTION
# What

We now have the billing status persisted in the database, and it has been verified as correct. Plus the billing report is now being generated from the persisted data.

We now need to change the verifications by RP report code to use the persisted value instead needing to download and compare the generated billing report for the same period.

It is probably a good idea to have a test that billing status is actually there.

The verifications report, historically, is a fairly long running report. Review queries to ensure it is making best use of indexes and create new as necessary.

Review options on the future of this report

# Why

To improve efficiency of billing report.

# How

Add index to `audit_events` table to improve efficiency of report.