### PR TITLE
Trello vhQUJhJH - Name all indexes

### DIFF
--- a/migrations/V000001__create_audit_events_table.sql
+++ b/migrations/V000001__create_audit_events_table.sql
@@ -12,4 +12,4 @@ CREATE TABLE audit.audit_events
 )
 TABLESPACE pg_default;
 ALTER TABLE audit.audit_events OWNER to event_system_owner;
-CREATE INDEX audit_events_time_stamp_idx1 ON audit.audit_events (time_stamp);
+CREATE INDEX audit_events_time_stamp_idx ON audit.audit_events (time_stamp);

--- a/migrations/V000001__create_audit_events_table.sql
+++ b/migrations/V000001__create_audit_events_table.sql
@@ -12,4 +12,4 @@ CREATE TABLE audit.audit_events
 )
 TABLESPACE pg_default;
 ALTER TABLE audit.audit_events OWNER to event_system_owner;
-CREATE INDEX ON audit.audit_events (time_stamp);
+CREATE INDEX audit_events_time_stamp_idx1 ON audit.audit_events (time_stamp);

--- a/migrations/V000002__create_billing_and_fraud_events_table.sql
+++ b/migrations/V000002__create_billing_and_fraud_events_table.sql
@@ -13,9 +13,9 @@ CREATE TABLE billing.billing_events
 )
 TABLESPACE pg_default;
 ALTER TABLE billing.billing_events OWNER to event_system_owner;
-CREATE INDEX ON billing.billing_events (time_stamp);
-CREATE INDEX ON billing.billing_events (hashed_persistent_id);
-CREATE INDEX ON billing.billing_events (provided_level_of_assurance);
+CREATE INDEX billing_events_time_stamp_idx1 ON billing.billing_events (time_stamp);
+CREATE INDEX billing_events_hashed_persistent_id_idx1 ON billing.billing_events (hashed_persistent_id);
+CREATE INDEX billing_events_provided_level_of_assurance_idx1 ON billing.billing_events (provided_level_of_assurance);
 
 CREATE TABLE billing.fraud_events
 (
@@ -29,5 +29,5 @@ CREATE TABLE billing.fraud_events
 )
 TABLESPACE pg_default;
 ALTER TABLE billing.fraud_events OWNER to event_system_owner;
-CREATE INDEX ON billing.fraud_events (time_stamp);
-CREATE INDEX ON billing.fraud_events (hashed_persistent_id);
+CREATE INDEX fraud_events_time_stamp_idx1 ON billing.fraud_events (time_stamp);
+CREATE INDEX fraud_events_hashed_persistent_id_idx1 ON billing.fraud_events (hashed_persistent_id);

--- a/migrations/V000002__create_billing_and_fraud_events_table.sql
+++ b/migrations/V000002__create_billing_and_fraud_events_table.sql
@@ -13,9 +13,9 @@ CREATE TABLE billing.billing_events
 )
 TABLESPACE pg_default;
 ALTER TABLE billing.billing_events OWNER to event_system_owner;
-CREATE INDEX billing_events_time_stamp_idx1 ON billing.billing_events (time_stamp);
-CREATE INDEX billing_events_hashed_persistent_id_idx1 ON billing.billing_events (hashed_persistent_id);
-CREATE INDEX billing_events_provided_level_of_assurance_idx1 ON billing.billing_events (provided_level_of_assurance);
+CREATE INDEX billing_events_time_stamp_idx ON billing.billing_events (time_stamp);
+CREATE INDEX billing_events_hashed_persistent_id_idx ON billing.billing_events (hashed_persistent_id);
+CREATE INDEX billing_events_provided_level_of_assurance_idx ON billing.billing_events (provided_level_of_assurance);
 
 CREATE TABLE billing.fraud_events
 (
@@ -29,5 +29,5 @@ CREATE TABLE billing.fraud_events
 )
 TABLESPACE pg_default;
 ALTER TABLE billing.fraud_events OWNER to event_system_owner;
-CREATE INDEX fraud_events_time_stamp_idx1 ON billing.fraud_events (time_stamp);
-CREATE INDEX fraud_events_hashed_persistent_id_idx1 ON billing.fraud_events (hashed_persistent_id);
+CREATE INDEX fraud_events_time_stamp_idx ON billing.fraud_events (time_stamp);
+CREATE INDEX fraud_events_hashed_persistent_id_idx ON billing.fraud_events (hashed_persistent_id);

--- a/migrations/V000003__create_indexes_for_audit_billing_and_fraud_events_tables.sql
+++ b/migrations/V000003__create_indexes_for_audit_billing_and_fraud_events_tables.sql
@@ -1,3 +1,3 @@
-CREATE INDEX audit_events_event_id_idx1 ON audit.audit_events (event_id);
-CREATE INDEX billing_events_session_id_idx1 ON billing.billing_events (session_id);
+CREATE INDEX audit_events_event_id_idx ON audit.audit_events (event_id);
+CREATE INDEX billing_events_session_id_idx ON billing.billing_events (session_id);
 CREATE INDEX fraud_events_session_id_idx ON billing.fraud_events (session_id);

--- a/migrations/V000003__create_indexes_for_audit_billing_and_fraud_events_tables.sql
+++ b/migrations/V000003__create_indexes_for_audit_billing_and_fraud_events_tables.sql
@@ -1,3 +1,3 @@
-CREATE INDEX ON audit.audit_events (event_id);
-CREATE INDEX ON billing.billing_events (session_id);
-CREATE INDEX ON billing.fraud_events (session_id);
+CREATE INDEX audit_events_event_id_idx1 ON audit.audit_events (event_id);
+CREATE INDEX billing_events_session_id_idx1 ON billing.billing_events (session_id);
+CREATE INDEX fraud_events_session_id_idx ON billing.fraud_events (session_id);

--- a/migrations/V20190712122100__create_indexes_on_billing_events_for_reports.sql
+++ b/migrations/V20190712122100__create_indexes_on_billing_events_for_reports.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY ON billing.billing_events USING btree (hashed_persistent_id, time_stamp);
+CREATE INDEX CONCURRENTLY billing_events_hashed_persistent_id_time_stamp_idx ON billing.billing_events USING btree (hashed_persistent_id, time_stamp);


### PR DESCRIPTION
Ensures all indexes in historical migrations are named for consistency across the databases.

Note that Flyway will reject these migrations due to checksum value changes. This will **need to be repaired manually**.

[Trello](https://trello.com/c/vhQUJhJH/28-index-re-concilation-across-environments)