### PR TITLE
Trello vhQUJhJH - Add migration for a pre-existing index

### DIFF
--- a/migrations/R__create_session_id_index_on_audit_events.sql
+++ b/migrations/R__create_session_id_index_on_audit_events.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_events_session_id_idx ON audit.audit_events (session_id);


### PR DESCRIPTION
This index already existed in the production DB. But not in all the other environments. We want to have it in our migrations, both so we know it's there, our tests will be using a production-like schema, we know to remove it if necessary, and it's applied consistently across the other environments. (Plus, code is meant to be self-documenting...)

Note that it has been made repeatable so that if the index needs removing, we only need to add a drop clause in this file.

[Trello](https://trello.com/c/vhQUJhJH/28-index-re-concilation-across-environments)