### PR TITLE
NDCBW4d3: Add service name to billing report

### DIFF
--- a/migrations/V20190724155000__add_transaction_entity_id_to_billing_events.sql
+++ b/migrations/V20190724155000__add_transaction_entity_id_to_billing_events.sql
@@ -1,0 +1,3 @@
+ALTER TABLE billing.billing_events
+  ADD COLUMN transaction_entity_id TEXT COLLATE pg_catalog."default" NULL
+;


### PR DESCRIPTION
## What

We often need to know which service to associate a billable event with. We do this by running the 'verifications by RP' report, which uses some data from the billing report but adds in a column containing the service name for each report.

We could just include that column in the billing report.

## Why

We could stop running the verifications by RP report. 

Secondary reports that use that report could be simplified.

## How

Add new migration to add new column to `billing_events` table.