### PR TITLE
NDCBW4d3: Add service name to billing report - Data Migration 2019

### DIFF
--- a/migrations/V20190730105400__copy_transaction_entity_id_to_billing_events_table_2019.sql
+++ b/migrations/V20190730105400__copy_transaction_entity_id_to_billing_events_table_2019.sql
@@ -1,0 +1,7 @@
+UPDATE billing.billing_events be
+   SET transaction_entity_id = ae.details ->> 'transaction_entity_id'
+  FROM audit.audit_events ae
+ WHERE be.time_stamp >= '2019-01-01' AND be.time_stamp < '2020-01-01'
+   AND be.transaction_entity_id IS NULL
+   AND ae.event_id = be.event_id
+;


### PR DESCRIPTION
## What

We often need to know which service to associate a billable event with. We do this by running the 'verifications by RP' report, which uses some data from the billing report but adds in a column containing the service name for each report.

We could just include that column in the billing report.

## Why

We could stop running the verifications by RP report. 

Secondary reports that use that report could be simplified.

## How

Add migration to copy transaction_entity_id to 2019 billing events