### PR TITLE
Q3k5BlPI: Fix incorrect event_ids in billing_status table - Pre-2018

### DIFF
--- a/migrations/V20190805143000_fix_incorrect_event_ids_in_billing_events_table_pre_2018.sql
+++ b/migrations/V20190805143000_fix_incorrect_event_ids_in_billing_events_table_pre_2018.sql
@@ -1,0 +1,16 @@
+UPDATE billing.billing_events be
+   SET event_id = ae.event_id,
+       transaction_entity_id = ae.details->>'transaction_entity_id'
+  FROM audit.audit_events ae
+ WHERE be.event_id IN (
+	SELECT be1.event_id
+	  FROM billing.billing_events be1
+	 INNER JOIN audit.audit_events ae1 ON ae1.event_id = be1.event_id
+     WHERE be1.time_stamp < '2018-01-01'
+	   AND NOT ( ae1.event_type = 'session_event' AND ae1.details ->> 'session_event_type' = 'idp_authn_succeeded' )
+ )
+ AND be.session_id = ae.session_id
+ AND be.time_stamp = ae.time_stamp
+ AND ae.event_type = 'session_event'
+ AND ae.details->>'session_event_type' = 'idp_authn_succeeded'
+;


### PR DESCRIPTION
## What

When we added the `event_id` column to the database last quarter and populated it by matching to data in the `audit_event` table, it seems that a small proportion of the rows matched to an incorrect event.

We need to identify these rows and update them with the correct `event_id`, ensuring that the corresponding `billing_status` record is also updated.

## Why

We need to ensure the correct data integrity so that reports for historical periods will run correctly.

## How

Add migration script to identify incorrect assigned `event_id`s and correct them (and the `transaction_entity_id`) for data before 2018-01-01.
