### PR TITLE
BAU - Add permissions to status table for IAM roles

### DIFF
--- a/permissions/create_iam_reader_permissions.sql
+++ b/permissions/create_iam_reader_permissions.sql
@@ -3,6 +3,7 @@ GRANT USAGE ON SCHEMA billing TO iam_reader;
 GRANT SELECT ON audit.audit_events TO iam_reader;
 GRANT SELECT ON billing.billing_events TO iam_reader;
 GRANT SELECT ON billing.fraud_events TO iam_reader;
+GRANT SELECT ON billing.billing_status TO iam_reader;
 GRANT TEMPORARY on DATABASE events TO iam_reader;
 -- Production and staging only
 GRANT SELECT ON billing.billing_idps TO iam_reader;


### PR DESCRIPTION
There is a new table in the DB. The reader / writer should probably be given access to them.