### PR TITLE
LbFKGVYc: Fixes to database schema for existing fraud data

### DIFF
--- a/migrations/V20190815122000__add_event_id_to_fraud_table.sql
+++ b/migrations/V20190815122000__add_event_id_to_fraud_table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE billing.fraud_events
+  ADD COLUMN event_id TEXT COLLATE pg_catalog."default" NULL,
+  ADD COLUMN transaction_entity_id TEXT COLLATE pg_catalog."default" NULL
+;


### PR DESCRIPTION
## What

As a developer, I want to be able to join between data in the `billing.fraud_events` table and the more detailed information in the `audit_events` table.

* For consistency with billing events, the primary key should be event ID
* Add the `transaction_entity_id` to fraud_events also

## How

Add `event_id` and `transaction_entity_id` columns to `billing.fraud_events`.