### PR TITLE
LbFKGVYc: Fixes to database schema for existing fraud data - Historical Data Update

### DIFF
--- a/migrations/V20190815160000__populate_event_id_and_transaction_entity_id_in_fraud_events_table.sql
+++ b/migrations/V20190815160000__populate_event_id_and_transaction_entity_id_in_fraud_events_table.sql
@@ -1,0 +1,10 @@
+UPDATE billing.fraud_events fe
+   SET event_id = ae.event_id,
+       transaction_entity_id = ae.details ->> 'transaction_entity_id'
+  FROM audit.audit_events ae
+ WHERE ae.session_id = fe.session_id
+   AND ae.time_stamp = fe.time_stamp
+   AND ae.event_type = 'session_event'
+   AND ae.details ->> 'session_event_type' = 'fraud_detected'
+   AND be.event_id IS NULL
+;


### PR DESCRIPTION
## What

As a developer, I want to be able to join between data in the `billing.fraud_events` table and the more detailed information in the `audit_events` table.

* For consistency with billing events, the primary key should be event ID
* Add the `transaction_entity_id` to fraud_events also

## Dependencies
https://github.com/alphagov/verify-event-system-database-scripts/pull/41

## How

Add update script to populate `event_id` and `transaction_entity_id`.