### PR TITLE
LbFKGVYc: Fixes to database schema for existing fraud data - Make Primary Key

### DIFF
--- a/migrations/V20190815161000__make_event_id_primary_key_index_on_fraud_events.sql
+++ b/migrations/V20190815161000__make_event_id_primary_key_index_on_fraud_events.sql
@@ -1,0 +1,2 @@
+ALTER TABLE billing.fraud_events ALTER COLUMN event_id SET NOT NULL;
+ALTER TABLE billing.fraud_events ADD CONSTRAINT fraud_events_pkey PRIMARY KEY(event_id);

--- a/migrations/V20190815161000__make_event_id_primary_key_index_on_fraud_events.sql
+++ b/migrations/V20190815161000__make_event_id_primary_key_index_on_fraud_events.sql
@@ -1,2 +1,5 @@
-ALTER TABLE billing.fraud_events ALTER COLUMN event_id SET NOT NULL;
+ALTER TABLE billing.fraud_events
+  ALTER COLUMN event_id SET NOT NULL,
+  ALTER COLUMN transaction_entity_id SET NOT NULL
+;
 ALTER TABLE billing.fraud_events ADD CONSTRAINT fraud_events_pkey PRIMARY KEY(event_id);


### PR DESCRIPTION
## What

As a developer, I want to be able to join between data in the `billing.fraud_events` table and the more detailed information in the `audit_events` table.

* For consistency with billing events, the primary key should be event ID
* Add the `transaction_entity_id` to fraud_events also

## Dependencies
https://github.com/alphagov/verify-event-system-database-scripts/pull/41
https://github.com/alphagov/verify-event-system-database-scripts/pull/42

## How

Make event_id `NOT NULL`
Create PRIMARY KEY index on `fraud_events` table.