### PR TITLE
BAU: Fix typo in UPDATE query causing migration to fail

### DIFF
--- a/migrations/V20190815160000__populate_event_id_and_transaction_entity_id_in_fraud_events_table.sql
+++ b/migrations/V20190815160000__populate_event_id_and_transaction_entity_id_in_fraud_events_table.sql
@@ -6,5 +6,5 @@ UPDATE billing.fraud_events fe
    AND ae.time_stamp = fe.time_stamp
    AND ae.event_type = 'session_event'
    AND ae.details ->> 'session_event_type' = 'fraud_detected'
-   AND be.event_id IS NULL
+   AND fe.event_id IS NULL
 ;


### PR DESCRIPTION
Correct mis-typed alias in `UPDATE` query causing syntax error.