### PR TITLE
YYdbmOJJ: Drop columns and index

### DIFF
--- a/migrations/V20191009113000__drop_unique_index_and_event_id_column_from_idp_fraud_events.sql
+++ b/migrations/V20191009113000__drop_unique_index_and_event_id_column_from_idp_fraud_events.sql
@@ -1,0 +1,4 @@
+ALTER TABLE idp_data.idp_fraud_events
+  DROP COLUMN event_id
+;
+DROP INDEX idp_data.idp_fraud_events_idp_entity_id_idp_event_id_idx;


### PR DESCRIPTION
## What

Further decisions have been made following the loading of real data, we have decided to alter our schema to reflect to remove the matching `event_id` column and to also remove the uniqueness constraint on the around the `idp_event_id` column.

## How

Drop `index idp_data.idp_fraud_events_idp_entity_id_idp_event_id_idx` as
uniqueness cannot be guaranteed.
Remove `event_id` column matching should be perform by user.