### PR TITLE
ps34 Add new preferred LOA billing column to billing_events

### DIFF
--- a/migrations/V20200428161000__add_preferred_loa_column_to_billing_events_table copy.sql
+++ b/migrations/V20200428161000__add_preferred_loa_column_to_billing_events_table copy.sql
@@ -1,0 +1,3 @@
+ALTER TABLE billing.billing_events
+  ADD COLUMN  preferred_level_of_assurance text COLLATE pg_catalog."default" NOT NULL
+;

--- a/migrations/V20200428161000__add_preferred_loa_column_to_billing_events_table copy.sql
+++ b/migrations/V20200428161000__add_preferred_loa_column_to_billing_events_table copy.sql
@@ -1,3 +1,3 @@
 ALTER TABLE billing.billing_events
-  ADD COLUMN  preferred_level_of_assurance text COLLATE pg_catalog."default" NOT NULL
+  ADD COLUMN  preferred_level_of_assurance text COLLATE pg_catalog."default" NULL
 ;

--- a/migrations/V20200428163000__alter_required_field_to_be_nullable_on_the_billing_events_table.sql
+++ b/migrations/V20200428163000__alter_required_field_to_be_nullable_on_the_billing_events_table.sql
@@ -1,3 +1,3 @@
 ALTER TABLE billing.billing_events
-  ALTER COLUMN  required_level_of_assurance NULL
+  ALTER COLUMN required_level_of_assurance DROP NOT NULL
 ;

--- a/migrations/V20200428163000__alter_required_field_to_be_nullable_on_the_billing_events_table.sql
+++ b/migrations/V20200428163000__alter_required_field_to_be_nullable_on_the_billing_events_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE billing.billing_events
+  ALTER COLUMN  required_level_of_assurance NULL
+;


### PR DESCRIPTION
This PR is one part of several across Verify to be able to support billing for new special case `LOA2,LOA1/exact` requests. It contains 2 database migrations.

Going forwards:

* The preferred LOA will be used as a part of the billing calculation (but it is not going to be backfilled, so the column should remain nullable).
* The required LOA is no longer recorded (and in fact was never needed).

The two migrations are:

* Adds a new (nullable) `preferred_level_of_assurance` column to the `billing_events` table.
* Sets the `required_level_of_assurance` column in the `billing_events` table to be nullable.

The `required_level_of_assurance` column will be removed in a future PR after all the billing alterations have been successful.

The full set of changes being made is laid out in:

* [ADR 36 billing changes plan](https://docs.google.com/document/d/1hblVU0wquj6Z3-b9V75z6jb1wt3Nnpjh2MNHxNGgTBE/edit?usp=sharing)

For context, please see:

* [ADR 35](https://github.com/alphagov/verify-architecture/blob/master/adr/0035-allow-specified-loa2-services-to-receive-loa1-identities.md) (sending LOA2,LOA1/exact requests to IDPs)
* [ADR 36](https://github.com/alphagov/verify-architecture/blob/master/adr/0036-support-billing-on-provided-loa.md) (changes to support billing for the new requests)