### PR TITLE
Drop required_level_of_assurance column

### DIFF
--- a/migrations/V20200602103000__drop_required_level_of_assurance_column_from_billing_events.sql
+++ b/migrations/V20200602103000__drop_required_level_of_assurance_column_from_billing_events.sql
@@ -1,0 +1,3 @@
+ALTER TABLE billing.billing_events
+  DROP COLUMN required_level_of_assurance
+;


### PR DESCRIPTION
- The required_level_of_assurance was never used for billing and is no longer being populated. Therefore we can
drop this column completely.

 Co-authored-by: Lewis Westbury <lewis.wetbury@digital.cabinet-office.gov.uk>