### PR TITLE
Hub-717: extract requestid from audits details 9 apr 6 jun 2020

### DIFF
--- a/migrations/V20200909180000__copyauditeventrequestid_into_audit_session_requests_table_for_09_apr_to_06_jun.sql
+++ b/migrations/V20200909180000__copyauditeventrequestid_into_audit_session_requests_table_for_09_apr_to_06_jun.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN
+	PERFORM audit.fn_inserts_audit_event_session_requests(begining => '2020-04-09', ending => '2020-06-07');
+END $$


### PR DESCRIPTION
see: https://govukverify.atlassian.net/browse/HUB-717

The audit events table in the event system database stores a json blob called 'details' containing a large number of fields. It's not indexed and slow to search.

Right now, we need to be able to look up the relationship between requestId and sessionId.

See here for info about how to access the event system database, and view the audit table: https://verify-team-manual.cloudapps.digital/documentation/architecture/event-system/access-events-database.html#audit-events

Construct a new table, with columns for session_id and request_id. This will need to be added to the verify-event-system-database-scripts repo to come into effect.

Write and run a sql query to extract these values from the audit_events table, and write them to the new table if they are not already present. (Run it on production-event-recording-system-db-replica.)

This PR extracts request_id data for the range between 09 April 2020 to 06-Jun-2020 , from the audit_events table to the new table audit_event_session_requests table