### PR TITLE
Hub-717: extract requestid from audits details import function

### DIFF
--- a/migrations/V20200907155900__create_audit_session_requests_table.sql
+++ b/migrations/V20200907155900__create_audit_session_requests_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE audit.audit_event_session_requests
+(
+    session_id           text COLLATE pg_catalog."default" NOT NULL,
+    request_id           text COLLATE pg_catalog."default" NOT NULL
+)

--- a/migrations/V20200909115900__create_min_audit_event_date_function.sql
+++ b/migrations/V20200909115900__create_min_audit_event_date_function.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION audit.min_audit_date() RETURNS varchar LANGUAGE SQL AS
+$$
+SELECT cast(MIN(time_stamp) as varchar) FROM audit.audit_events;
+$$;
+
+

--- a/migrations/V20200909173300__create_max_audit_event_date_function.sql
+++ b/migrations/V20200909173300__create_max_audit_event_date_function.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE FUNCTION audit.max_audit_date() RETURNS varchar LANGUAGE SQL AS
+$$
+SELECT cast(MAX(time_stamp) as varchar) FROM audit.audit_events;
+$$;

--- a/migrations/V20200909173500__create_audit_session_requests_function.sql
+++ b/migrations/V20200909173500__create_audit_session_requests_function.sql
@@ -1,0 +1,39 @@
+
+CREATE OR REPLACE FUNCTION audit.fn_inserts_audit_event_session_requests
+(
+	begining character varying DEFAULT audit.min_audit_date(),
+	ending character varying DEFAULT audit.max_audit_date()
+)
+RETURNS void
+LANGUAGE 'plpgsql'
+AS
+$BODY$
+BEGIN
+	INSERT INTO audit.audit_event_session_requests
+	SELECT
+	source.session_id AS session_id,
+	source.request_id AS request_id
+	FROM
+	(
+		SELECT session_id,
+		CASE
+			WHEN details ? 'request_id' THEN details ->> 'request_id'
+			WHEN details ? 'message_id' THEN details ->> 'message_id'
+		END AS request_id
+		FROM
+		(
+			SELECT session_id, details FROM audit.audit_events
+			WHERE time_stamp >= TO_DATE(begining, 'YYYY-MM-DD')
+			AND time_stamp < TO_DATE(ending, 'YYYY-MM-DD')
+		)
+		AS filtered_audits
+		WHERE details ? 'request_id' OR details ? 'message_id'
+		GROUP BY session_id, request_id
+	)
+	AS source
+	LEFT JOIN audit.audit_event_session_requests AS destination
+	ON source.session_id = destination.session_id
+	AND source.request_id = destination.request_id
+  WHERE destination.session_id IS NULL AND destination.request_id IS NULL;
+END;
+$BODY$;


### PR DESCRIPTION
See: https://govukverify.atlassian.net/browse/HUB-717

This PR contains the creation script for the new table (**audit_event_session_requests**) and core functions that would be used to import request and session ids from the audit_events table to the new table.

1. **fn_inserts_audit_event_session_requests** can be called to start the import, it uses 2 helper functions to find the earliest date i.e. **min_audit_date()** and the latest date i.e. **max_audit_date()** functions. However, since the audit_events table is very large the intention is the run separate migration script files for shorter ranges i.e. a script file can be created that runs the following command see https://github.com/alphagov/verify-event-system-database-scripts/pull/50

```
DO $$ BEGIN
	PERFORM audit.fn_inserts_audit_event_session_requests(begining => '2020-04-09', ending => '2020-06-07');
END $$
```

The above would import session and request ids between the 9th of April and up until the 6th of June.
