### PR TITLE
HUB-717: copy request_id before 2016

### DIFF
--- a/migrations/V20200909174000__copyauditeventrequestid_into_audit_session_requests_table_before_2016.sql
+++ b/migrations/V20200909174000__copyauditeventrequestid_into_audit_session_requests_table_before_2016.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN
+	PERFORM audit.fn_inserts_audit_event_session_requests(ending => '2016-01-01');
+END $$


### PR DESCRIPTION
see: https://govukverify.atlassian.net/browse/HUB-717
Due to the large amount of records in audit_events table, this is the first of a series of PR to copy request_id and session_ids into the new table **audit_session_requests_table**
Copies all request_id and session_ids before 2016 into the **audit_session_requests_table** from audit_events table

Here `fn_inserts_audit_event_session_requests` begining parameter defaults to the earliest date calculated by the
`audit.max_audit_date() ` function