### PR TITLE
HUB-717: request_id timestamp between 2k16 & 2k17

### DIFF
--- a/migrations/V20200909180600__copyauditeventrequestid_into_audit_session_requests_table_2016.sql
+++ b/migrations/V20200909180600__copyauditeventrequestid_into_audit_session_requests_table_2016.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN
+	PERFORM audit.fn_inserts_audit_event_session_requests(begining => '2016-01-01', ending => '2017-01-01');
+END $$


### PR DESCRIPTION
see: https://govukverify.atlassian.net/browse/HUB-717

Copies request_id and session_id between 2016 and 2017 in audit_events
table by setting beginning = '2016-01-01' and ending = '2017-01-01' parameters
of fn_inserts_audit_event_session_requests