### PR TITLE
HUB-717: request_id timestamp between 2k17 & 2k18

### DIFF
--- a/migrations/V20200909180800__copyauditeventrequestid_into_audit_session_requests_table_2017.sql
+++ b/migrations/V20200909180800__copyauditeventrequestid_into_audit_session_requests_table_2017.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN
+	PERFORM audit.fn_inserts_audit_event_session_requests(begining => '2017-01-01', ending => '2018-01-01');
+END $$


### PR DESCRIPTION
Copies request_id and session_id between 2017 and 2018 in audit_events
table by setting begining = '2017-01-01' and ending = '2018-01-01' parameters
of fn_inserts_audit_event_session_requests