### PR TITLE
HUB-717: request_id timestamp between 2k18 & 2k19

### DIFF
--- a/migrations/V20200909180900__copyauditeventrequestid_into_audit_session_requests_table_2018.sql
+++ b/migrations/V20200909180900__copyauditeventrequestid_into_audit_session_requests_table_2018.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN
+	PERFORM audit.fn_inserts_audit_event_session_requests(begining => '2018-01-01', ending => '2019-01-01');
+END $$


### PR DESCRIPTION
Copies request_id and session_id between 2018 and 2019 sets
begining = '2018-01-01' and ending = '2019-01-01' in function
fn_inserts_audit_event_session_requests