### PR TITLE
HUB-717: request_id timestamp 1st half of 2k19

### DIFF
--- a/migrations/V20200909181000__copyauditeventrequestid_into_audit_session_requests_table_1sthalf_2019.sql
+++ b/migrations/V20200909181000__copyauditeventrequestid_into_audit_session_requests_table_1sthalf_2019.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN
+	PERFORM audit.fn_inserts_audit_event_session_requests(begining => '2019-01-01', ending => '2019-06-01');
+END $$


### PR DESCRIPTION
Copies request_id and session_id for the 1st half of 2019 sets
begining = '2019-01-01' and ending = '2019-06-01' in function
fn_inserts_audit_event_session_requests