### PR TITLE
HUB-717: alter ownership on session request object

### DIFF
--- a/migrations/V20200915093000__alter_audit_session_requests_owner.sql
+++ b/migrations/V20200915093000__alter_audit_session_requests_owner.sql
@@ -1,0 +1,4 @@
+ALTER TABLE audit.audit_event_session_requests OWNER to event_system_owner;
+ALTER FUNCTION audit.min_audit_date OWNER to event_system_owner;
+ALTER FUNCTION audit.max_audit_date OWNER to event_system_owner;
+ALTER FUNCTION audit.fn_inserts_audit_event_session_requests OWNER to event_system_owner;


### PR DESCRIPTION
This commit changes ownership on the audit session requests object i.e
- audit_event_session_request table
- min_audit_date function
- max_audit_date function
from dbmigrator to event_system_owner