### PR TITLE
HUB-717: Add migration for initial two days of request ids

### DIFF
--- a/migrations/V20200915142000__migrate_request_ids_to_audit_event_session_requests_table_for_20200409-10.sql
+++ b/migrations/V20200915142000__migrate_request_ids_to_audit_event_session_requests_table_for_20200409-10.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2020-04-09', ending => '2020-04-11');


### PR DESCRIPTION
A function has been created to copy request_id and session_id data from
the main audit_events table to the new audit_event_session_requests
table.

It's been realised that there is a _lot_ of data that will be copied.
This initial migration is to copy data for a conservative two days of
the initial date period we're interested in. We will observe how this
migration runs and adjust future migrations as appropriate.

This migration file has been tested against the local set up described in 
the README.