### PR TITLE
HUB-717: Add migration for request_ids for April 10-17

### DIFF
--- a/migrations/V20200915162000__migrate_request_ids_to_audit_event_session_requests_table_for_20200410-17.sql
+++ b/migrations/V20200915162000__migrate_request_ids_to_audit_event_session_requests_table_for_20200410-17.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2020-04-10', ending => '2020-04-17');


### PR DESCRIPTION
This is being done in small increments to prevent any issues with
locking the DB. The previous migration operated on two days worth of
data and the DB instance had no issues. CPU usage rose to 5% and the
time for the migrations to happen was not abnormal. The event system db
dashboard showed no worrying stats.

This migration will operated on a week of data. After this we could step
up to a month.