### PR TITLE
HUB-717: Extract request_id for May 17 to Sept 17

### DIFF
--- a/migrations/V20200916091500__migrate_request_ids_to_audit_event_session_requests_table_for_20200517-0917.sql
+++ b/migrations/V20200916091500__migrate_request_ids_to_audit_event_session_requests_table_for_20200517-0917.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2020-05-17', ending => '2020-09-17');


### PR DESCRIPTION
The previous migration was for one month and the DB handled it like a
champ.

This migration is for four months and will mean that all data since
since the 9th April up until the point this migration is run will be
migrated.

After this I will proceed in 6 month or one year increments from the
first row in the audit_events table up until 9th April.