### PR TITLE
HUB-717: Add migration for request_id for 20140905 to 20150505

### DIFF
--- a/migrations/V20200916112500__migrate_request_ids_to_audit_event_session_requests_table_for_20140905-20150505.sql
+++ b/migrations/V20200916112500__migrate_request_ids_to_audit_event_session_requests_table_for_20140905-20150505.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(ending => '2015-05-05');


### PR DESCRIPTION
The previous migration was for a four month period and ran without
issues. This increases the time period to eight months.

As we have now migrated the most recent data this will operate on the
earliest time_stamp and later. The default argument to the function,
`beginning` is omitted here so the default is used - the earliest
time_stamp in the table. Having inspected the DB this is 5 September
2014.