### PR TITLE
HUB-717: Add migration for request_id for 20150505 to 20170101

### DIFF
--- a/migrations/V20200916135500__migrate_request_ids_to_audit_event_session_requests_table_for_20150505-20170101.sql
+++ b/migrations/V20200916135500__migrate_request_ids_to_audit_event_session_requests_table_for_20150505-20170101.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2015-05-05', ending => '2017-01-01');


### PR DESCRIPTION
The last migration was for 8 months and ran without issue.

This migration is for a approximately 19 month period, so a little more
than double. It makes the date ranges more sensible though.