### PR TITLE
HUB-717: Migrate request_ids for 2017

### DIFF
--- a/migrations/V20200916154500__migrate_request_ids_to_audit_event_session_requests_table_for_2017.sql
+++ b/migrations/V20200916154500__migrate_request_ids_to_audit_event_session_requests_table_for_2017.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2017-01-01', ending => '2018-01-01');


### PR DESCRIPTION
The previous migration of 18 months was successful but took 35 minutes
and caused the script running it to falsely report a failure. As such
I've reduced the time period to 12 months.