### PR TITLE
HUB-717: Add migration for request_id for 20200101 to 20200409

### DIFF
--- a/migrations/V20200916155000__migrate_request_ids_to_audit_event_session_requests_table_for_20200101-to-20200409.sql
+++ b/migrations/V20200916155000__migrate_request_ids_to_audit_event_session_requests_table_for_20200101-to-20200409.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2020-01-01', ending => '2020-04-09');


### PR DESCRIPTION
The data from 20200409 onwards has already been migrated.