### PR TITLE
HUB-717: Add migration for request_id for 20190101-0701

### DIFF
--- a/migrations/V20200917120000__migrate_request_ids_to_audit_event_session_requests_table_for_20190101-0701.sql
+++ b/migrations/V20200917120000__migrate_request_ids_to_audit_event_session_requests_table_for_20190101-0701.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2019-01-01', ending => '2019-07-01');


### PR DESCRIPTION
We've found that there are more events the later the date range and the
migrations were taking longer to run. I'm going to migrate 2019 in two
parts to address this. This is the first half of the year.