### PR TITLE
HUB-717: Add request_id migration for 20190701 to 20200101

### DIFF
--- a/migrations/V20200917120300__migrate_request_ids_to_audit_event_session_requests_table_for_20190701-20200101.sql
+++ b/migrations/V20200917120300__migrate_request_ids_to_audit_event_session_requests_table_for_20190701-20200101.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2019-07-01', ending => '2020-01-01');


### PR DESCRIPTION
This is second half of 2019. 2019 has more events than 2018 so the
migration is being done in two parts rather than the whole year in one
shot.