### PR TITLE
BAU add migration to link session_id, request_id for 2020-04 to 2020-09-25

### DIFF
--- a/migrations/V202009251643260__migrate_request_ids_to_audit_event_session_requests_table_for_20200409-to-20200925.sql
+++ b/migrations/V202009251643260__migrate_request_ids_to_audit_event_session_requests_table_for_20200409-to-20200925.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2020-04-09', ending => '2020-09-25');

--- a/migrations/V202009251644480__create_index_on_session_id_in_audit_event_session_requests_table.sql
+++ b/migrations/V202009251644480__create_index_on_session_id_in_audit_event_session_requests_table.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (session_id);

--- a/migrations/V202009251644480__create_index_on_session_id_in_audit_event_session_requests_table.sql
+++ b/migrations/V202009251644480__create_index_on_session_id_in_audit_event_session_requests_table.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (session_id);
+CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (session_id, request_id);

--- a/migrations/V202009251645450__create_index_on_request_id_in_audit_event_session_requests_table.sql
+++ b/migrations/V202009251645450__create_index_on_request_id_in_audit_event_session_requests_table.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (request_id);
+CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (request_id, session_id);

--- a/migrations/V202009251645450__create_index_on_request_id_in_audit_event_session_requests_table.sql
+++ b/migrations/V202009251645450__create_index_on_request_id_in_audit_event_session_requests_table.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (request_id);


### PR DESCRIPTION
* Add an additional migration for the `audit_events_session_requests` table from 2020-04-01 to 2020-09-25.
* Add indices on `request_id` and `session_id` columns the `audit_events_session_requests` table.

For more info on the function, see [migration V20200909173500](https://github.com/alphagov/verify-event-system-database-scripts/blob/master/migrations/V20200909173500__create_audit_session_requests_function.sql), where it was created.