### PR TITLE
HUB-719 recreate table and function

### DIFF
--- a/migrations/V202009291300110__recreate_audit_session_requests_table.sql
+++ b/migrations/V202009291300110__recreate_audit_session_requests_table.sql
@@ -1,0 +1,8 @@
+DROP TABLE audit.audit_event_session_requests;
+
+CREATE TABLE audit.audit_event_session_requests
+(
+    session_id           text COLLATE pg_catalog."default" NOT NULL,
+    request_id           text COLLATE pg_catalog."default" NOT NULL,
+    details              jsonb
+);

--- a/migrations/V202009291430110__recreate_audit_session_requests_function.sql
+++ b/migrations/V202009291430110__recreate_audit_session_requests_function.sql
@@ -1,0 +1,43 @@
+
+CREATE OR REPLACE FUNCTION audit.fn_inserts_audit_event_session_requests
+(
+	begining character varying DEFAULT audit.min_audit_date(),
+	ending character varying DEFAULT audit.max_audit_date()
+)
+RETURNS void
+LANGUAGE 'plpgsql'
+AS
+$BODY$
+BEGIN
+	INSERT INTO audit.audit_event_session_requests
+	SELECT
+	source.session_id AS session_id,
+	source.request_id AS request_id,
+	source.details AS details
+	FROM
+	(
+		SELECT
+			session_id,
+			CASE
+				WHEN details ? 'request_id' AND NOT details ? 'message_id' THEN details ->> 'request_id'
+				WHEN details ? 'message_id' AND NOT details ? 'request_id' THEN details ->> 'message_id'
+				WHEN details ? 'request_id' AND details ? 'message_id'     THEN details ->> 'request_id'
+			END AS request_id,
+			details
+		FROM
+		(
+			SELECT session_id, details FROM audit.audit_events
+			WHERE time_stamp >= TO_DATE(begining, 'YYYY-MM-DD')
+			AND time_stamp < TO_DATE(ending, 'YYYY-MM-DD')
+		)
+		AS filtered_audits
+		WHERE (details ? 'request_id' AND char_length(details ->> 'request_id') > 0)
+		   OR (details ? 'message_id' AND char_length(details ->> 'message_id') > 0)
+	)
+	AS source
+	LEFT JOIN audit.audit_event_session_requests AS destination
+	ON source.session_id = destination.session_id
+	AND source.request_id = destination.request_id
+  WHERE destination.session_id IS NULL AND destination.request_id IS NULL;
+END;
+$BODY$;

--- a/migrations/V202009291444110__migrate_request_ids_to_audit_event_session_requests_table_for_20200409_to_present.sql
+++ b/migrations/V202009291444110__migrate_request_ids_to_audit_event_session_requests_table_for_20200409_to_present.sql
@@ -1,0 +1,1 @@
+SELECT audit.fn_inserts_audit_event_session_requests(begining => '2020-04-08', ending => '2020-06-07');

--- a/migrations/V202009291646450__create_index_on_request_id_in_audit_event_session_requests_table_again.sql
+++ b/migrations/V202009291646450__create_index_on_request_id_in_audit_event_session_requests_table_again.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (request_id, session_id);

--- a/migrations/V202009291646480__create_index_on_session_id_in_audit_event_session_requests_table_again.sql
+++ b/migrations/V202009291646480__create_index_on_session_id_in_audit_event_session_requests_table_again.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY ON audit.audit_event_session_requests (session_id, request_id);


### PR DESCRIPTION
* Recreates the function for migrating data to `audit_event_session_requests`
* Recreates the `audit_event_session_requests` table with a column for `details` as jsonb
* Disallows accidental overwrite of useful values for `request_id` by empty strings
* Fetches only data from relevant dates for HUB-719 query
